### PR TITLE
work-in-progress: redis integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,6 @@ docker run -p 6379:6379 -it redis:latest --requirepass "abcd1234"
 # without password
 docker run -p 6379:6379 -it redis:latest
 ```
-or (https://developer.redis.com/create/docker/redis-on-docker/)
-```
-docker run -d --name redis-stack-server -p 6379:6379 redis/redis-stack-server:latest
-```
 
 ## Example lona script
 ```python
@@ -57,14 +53,12 @@ class Index(View):
     def handle_request(self, request):
         session = request.user.session
 
-        # set key, value
-        session.set("foo", 123)
-
-        # returns True
-        session.exists("foo")
-
-        # given key, get value
-        foo = session.get("foo")
+        session.set("foo", 123) # set key, value
+        session.exists("foo") # returns True
+        foo = session.get("foo") # given key, get value
+        session.delete("foo") # returns True
+        session.delete("foo") # returns False, "foo" was already deleted
+        session.delete("bar") # returns False, "bar" doesn't exist
 
         return HTML(
             H1("Hello World"),
@@ -91,16 +85,14 @@ session.set(
 )
 ```
 ## Store key-values that expire
-Arguments are passed through to Redis set() command
+All options are passed through to Redis set() command
 
-All parameters are available in lona-redis
-
-(https://redis.readthedocs.io/en/latest/commands.html#redis.commands.core.CoreCommands.set)
+https://redis.readthedocs.io/en/latest/commands.html#redis.commands.core.CoreCommands.set
 ```python
 # "foo" will expire in 5 seconds
 session.set("foo", 123, ex=5)
 ```
-### Using Redis commands directly
+## Use Redis commands directly
 **Always access the key with session.redis_key()**
 
 ```python

--- a/README.md
+++ b/README.md
@@ -4,15 +4,17 @@
 ![Python Version](https://img.shields.io/pypi/pyversions/lona-redis.svg)
 ![Latest Version](https://img.shields.io/pypi/v/lona-redis.svg)
 
+lona-redis uses Redis as a key-value store to store server side cookies.
+
+lona-redis also allows direct access to the Redis connection for direct execution of Redis commands.
 
 ## Installation
 
-lona-picocss can be installed using pip
+lona-redis can be installed using pip
 
 ```
 pip install lona-redis
 ```
-
 
 ## Using Sessions
 
@@ -24,16 +26,8 @@ MIDDLEWARES = [
 ]
 ```
 
-## What is Redis
-Redis is key-value store.
-
-## What is lona-redis
-lona-redis uses redis-py to let lona scripts store session data (key-values) in Redis.
-
-lona-redis also allows direct access to the Redis connection for direct execution of Redis commands
-
-## Start up Redis (using Docker)
-
+## Start up Redis
+Using Docker
 ```
 docker run -p 6379:6379 -it redis:latest --requirepass "abcd1234"
 
@@ -44,7 +38,6 @@ or (https://developer.redis.com/create/docker/redis-on-docker/)
 ```
 docker run -d --name redis-stack-server -p 6379:6379 redis/redis-stack-server:latest
 ```
-
 
 ## Example lona script
 ```python
@@ -57,23 +50,68 @@ app.settings.SESSIONS = True
 app.settings.MIDDLEWARES = [
     "lona_redis.middlewares.RedisSessionMiddleware",
 ]
+app.settings.REDIS_CONNECTION = {"password": "abcd1234"}
 
 @app.route("/")
 class Index(View):
-	def handle_request(self, request):
-		# set key, value
-		request.user.session.set(foo=123)
+    def handle_request(self, request):
+        session = request.user.session
 
-		# given key, get value
-		foo = request.user.session.get("foo")
+        # set key, value
+        session.set("foo", 123)
 
-		return HTML(
+        # returns True
+        session.exists("foo")
+
+        # given key, get value
+        foo = session.get("foo")
+
+        return HTML(
             H1("Hello World"),
-            # P("Lorem Ipsum"),
         )
-
 ```
 
-## More examples of getting & setting session data
+## Store other data types
+Any data type that can be pickled can be stored
 ```python
+session.set("str_var", "hello world")
+session.set("list_var", [1, 2.222, "hello world"])
+session.set("int_var", 123)
+session.set("float_var", 123.456)
+session.set("tuple_var", (1, 2, 3))
+session.set("dict_var", {"a": 1, "b": 2})
+session.set("boolean_var", True)
+session.set(
+    "mixed_types_var",
+    {
+        "a": [1, 2, 3],
+        "b": {"a": 1, "b": 2},
+        "c": (4, 5, 6),
+    },
+)
+```
+## Store key-values that expire
+Arguments are passed through to Redis set() command
+
+All parameters are available in lona-redis
+
+(https://redis.readthedocs.io/en/latest/commands.html#redis.commands.core.CoreCommands.set)
+```python
+# "foo" will expire in 5 seconds
+session.set("foo", 123, ex=5)
+```
+### Using Redis commands directly
+**Always access the key with session.redis_key()**
+
+```python
+# Set the value of key name to value if key doesn’t exist
+# https://redis.readthedocs.io/en/latest/commands.html#redis.commands.core.CoreCommands.setnx
+session.r.setnx(session.redis_key("count"), 1)
+
+# Increments the value of key by amount. If no key exists, the value will be initialized as amount
+# https://redis.readthedocs.io/en/latest/commands.html#redis.commands.core.CoreCommands.incr
+count = session.r.incr(session.redis_key("count"), amount=1)
+
+# when using r.get, value returned is in bytes - need to manage this yourself
+session.r.get(session.redis_key("count"))
 ```

--- a/README.md
+++ b/README.md
@@ -23,3 +23,57 @@ MIDDLEWARES = [
     'lona_redis.middlewares.RedisSessionMiddleware',
 ]
 ```
+
+## What is Redis
+Redis is key-value store.
+
+## What is lona-redis
+lona-redis uses redis-py to let lona scripts store session data (key-values) in Redis.
+
+lona-redis also allows direct access to the Redis connection for direct execution of Redis commands
+
+## Start up Redis (using Docker)
+
+```
+docker run -p 6379:6379 -it redis:latest --requirepass "abcd1234"
+
+# without password
+docker run -p 6379:6379 -it redis:latest
+```
+or (https://developer.redis.com/create/docker/redis-on-docker/)
+```
+docker run -d --name redis-stack-server -p 6379:6379 redis/redis-stack-server:latest
+```
+
+
+## Example lona script
+```python
+from lona import App, View
+from lona.html import H1, HTML
+
+app = App(__file__)
+
+app.settings.SESSIONS = True
+app.settings.MIDDLEWARES = [
+    "lona_redis.middlewares.RedisSessionMiddleware",
+]
+
+@app.route("/")
+class Index(View):
+	def handle_request(self, request):
+		# set key, value
+		request.user.session.set(foo=123)
+
+		# given key, get value
+		foo = request.user.session.get("foo")
+
+		return HTML(
+            H1("Hello World"),
+            # P("Lorem Ipsum"),
+        )
+
+```
+
+## More examples of getting & setting session data
+```python
+```

--- a/example_redis.py
+++ b/example_redis.py
@@ -10,7 +10,7 @@ from lona.html import H1, HTML, P
 from loguru import logger
 
 
-# NOTE start Redis before starting this lona script
+# NOTE start Redis before starting this lona script, eg:
 # docker run -p 6379:6379 -it redis:latest --requirepass "abcd1234"
 
 app = App(__file__)
@@ -25,26 +25,34 @@ app.settings.MIDDLEWARES = [
 
 # FIXME suggested way to pass Redis connection settings
 # there are many many kwargs: https://redis.readthedocs.io/en/latest/connections.html
+# app.settings.REDIS_CONNECTION = {"password": "abcd1234", "decode_responses": False}
 app.settings.REDIS_CONNECTION = {"password": "abcd1234"}
+# app.settings.REDIS_CONNECTION = {}
 
 
 @app.route("/")
 class Index(View):
     def handle_request(self, request):
         #
+        # NOTE THE "EASY" WAY
         # NOTE examples of using request.user.session.set, request.user.session.get
         #
 
-        # request.user.session.set(foo=123)
-        # OR
-        # foo = 123
-        # request.user.session.set(foo=foo)
-        # foo = request.user.session.get("foo")
-        # logger.debug(f"{foo=}")
+        # NOTE set single value
+        request.user.session.set(foo=999)
 
-        # NOTE example of getting the actual redis key given user's key
-        # logger.debug(f"{request.user.session._actual_redis_key('foo')=}")
+        # NOTE get single value
+        foo = request.user.session.get("foo")
+        logger.debug(f"{foo=}")
 
+        # NOTE set multiple values
+        request.user.session.set(foo=123, bar=4.56, baz="hello world")
+
+        # NOTE get multiple values
+        var_foo, var_bar, var_baz = request.user.session.get("foo", "bar", "baz")
+        logger.debug(f"{var_foo=}, {var_bar=}, {var_baz=}")
+
+        # NOTE store various types of values
         request.user.session.set(str_var="hello world")
         request.user.session.set(list_var=[1, 2.222, "hello world"])
         request.user.session.set(int_var=123)
@@ -67,6 +75,7 @@ class Index(View):
             mixed_var_2={
                 "a": [1, 2, 3],
                 "b": {"a": 1, "b": 2},
+                "c": (4,5,6),
             }
         )
 
@@ -82,10 +91,30 @@ class Index(View):
 
         #
         # NOTE examples of using Redis commands directly
-        #
         # https://redis.readthedocs.io/en/latest/commands.html#core-commands
+        #
+
+        # NOTE set key directly in Redis
+        # NOTE just an example, DON'T DO THIS
+        # should always use request.user.session.redis_key()
+        # Otherwise another session will overwrite this key
         request.user.session.r.set("myKey", "thevalueofmykey")
         myKey = request.user.session.r.get("myKey")
+
+        # NOTE Set the value of key name to value if key doesn’t exist
+        # request.user.session.r.setnx(request.user.session.redis_key("count"), 1)
+
+        # Increments the value of key by amount. If no key exists, the value will be initialized as amount
+        count = request.user.session.r.incr(
+            request.user.session.redis_key("count"), amount=1
+        )
+
+        # NOTE when using r.get, value returned is in bytes - need to manage this yourself
+        count = request.user.session.r.get(request.user.session.redis_key("count"))
+
+        logger.debug(f"{count=}")
+
+        # NOTE show all keys
         all_keys = request.user.session.r.keys()
         logger.debug(f"{all_keys=}")
 

--- a/example_redis.py
+++ b/example_redis.py
@@ -24,6 +24,10 @@ app.settings.REDIS_PASSWORD = "abcd1234"
 @app.route("/")
 class Index(View):
     def handle_request(self, request):
+        #
+        # NOTE examples of using request.user.session.set, request.user.session.get
+        #
+
         # request.user.session.set(foo=123)
         # OR
         # foo = 123
@@ -32,13 +36,44 @@ class Index(View):
         # logger.debug(f"{foo=}")
         # logger.debug(f"{request.user.session._actual_redis_key('foo')=}")
 
-        list_var = [1, 2.222, "string"]
-        int_var = 123
-        float_var = 123.456
-        tuple_var = (1, 2, 3)
-        dict_var = {"a": 1, "b": 2}
+        request.user.session.set(str_var="hello world")
+        request.user.session.set(list_var=[1, 2.222, "hello world"])
+        request.user.session.set(int_var=123)
+        request.user.session.set(float_var=123.456)
+        request.user.session.set(tuple_var=(1, 2, 3))
+        request.user.session.set(dict_var={"a": 1, "b": 2})
+        request.user.session.set(boolean_var=True)
+        request.user.session.set(
+            mixed_var_1=[
+                True,
+                {"a": 1, "b": 2},
+                (1, 2, 3),
+                123.456,
+                123,
+                [1, 2.222, "hello world"],
+                "hello world",
+            ]
+        )
+        request.user.session.set(
+            mixed_var_2={
+                "a": [1, 2, 3],
+                "b": {"a": 1, "b": 2},
+            }
+        )
 
-        # NOTE example of using Redis commands directly
+        logger.debug(f"{request.user.session.get('str_var')=}")
+        logger.debug(f"{request.user.session.get('list_var')=}")
+        logger.debug(f"{request.user.session.get('int_var')=}")
+        logger.debug(f"{request.user.session.get('float_var')=}")
+        logger.debug(f"{request.user.session.get('tuple_var')=}")
+        logger.debug(f"{request.user.session.get('dict_var')=}")
+        logger.debug(f"{request.user.session.get('boolean_var')=}")
+        logger.debug(f"{request.user.session.get('mixed_var_1')=}")
+        logger.debug(f"{request.user.session.get('mixed_var_2')=}")
+
+        #
+        # NOTE examples of using Redis commands directly
+        #
         # https://redis.readthedocs.io/en/latest/commands.html#core-commands
         request.user.session.r.set("myKey", "thevalueofmykey")
         myKey = request.user.session.r.get("myKey")
@@ -48,7 +83,7 @@ class Index(View):
         # return HTML(H1(request.user.session["count"]))
         return HTML(
             H1("Hello World"),
-            #    P("Lorem Ipsum"),
+            # P("Lorem Ipsum"),
         )
 
 

--- a/example_redis.py
+++ b/example_redis.py
@@ -1,0 +1,55 @@
+"""
+    example_redis.py
+
+    test redis middleware
+"""
+
+from lona import App, View
+from lona.html import H1, HTML, P
+
+from loguru import logger
+
+
+app = App(__file__)
+
+app.settings.SESSIONS = True
+app.settings.MIDDLEWARES = [
+    "lona_redis.middlewares.RedisSessionMiddleware",
+]
+
+app.settings.REDIS_USER = "some_redis_user"
+app.settings.REDIS_PASSWORD = "abcd1234"
+
+
+@app.route("/")
+class Index(View):
+    def handle_request(self, request):
+        # request.user.session.set(foo=123)
+        # OR
+        # foo = 123
+        # request.user.session.set(foo=foo)
+        # foo = request.user.session.get("foo")
+        # logger.debug(f"{foo=}")
+        # logger.debug(f"{request.user.session._actual_redis_key('foo')=}")
+
+        list_var = [1, 2.222, "string"]
+        int_var = 123
+        float_var = 123.456
+        tuple_var = (1, 2, 3)
+        dict_var = {"a": 1, "b": 2}
+
+        # NOTE example of using Redis commands directly
+        # https://redis.readthedocs.io/en/latest/commands.html#core-commands
+        request.user.session.r.set("myKey", "thevalueofmykey")
+        myKey = request.user.session.r.get("myKey")
+        all_keys = request.user.session.r.keys()
+        logger.debug(f"{all_keys=}")
+
+        # return HTML(H1(request.user.session["count"]))
+        return HTML(
+            H1("Hello World"),
+            #    P("Lorem Ipsum"),
+        )
+
+
+app.run()

--- a/example_redis.py
+++ b/example_redis.py
@@ -39,7 +39,10 @@ class Index(View):
         #
 
         # NOTE set single value
-        request.user.session.set(foo=999)
+        # request.user.session.set(foo=999)
+        request.user.session.set("foo", 999)
+        # testing throw error
+        # request.user.session.set("foo", 999, 345)
 
         # NOTE get single value
         foo = request.user.session.get("foo")
@@ -75,7 +78,7 @@ class Index(View):
             mixed_var_2={
                 "a": [1, 2, 3],
                 "b": {"a": 1, "b": 2},
-                "c": (4,5,6),
+                "c": (4, 5, 6),
             }
         )
 

--- a/example_redis.py
+++ b/example_redis.py
@@ -48,6 +48,11 @@ class Index(View):
         logger.debug(f"{session.get('foo')=}")
         logger.debug(f"{session.get('bar')=}")
 
+        # NOTE delete
+        logger.debug(f"{session.delete('foo')=}")
+        logger.debug(f"{session.delete('foo')=}")
+        logger.debug(f"{session.delete('bar')=}")
+
         # NOTE store various types of values
         session.set("str_var", "hello world")
         session.set("list_var", [1, 2.222, "hello world"])
@@ -96,8 +101,8 @@ class Index(View):
         # NOTE just an example, DON'T DO THIS
         # should always use session.redis_key()
         # Otherwise another session will overwrite this key
-        session.r.set("myKey", "thevalueofmykey")
-        myKey = session.r.get("myKey")
+        # session.r.set("myKey", "thevalueofmykey")
+        # myKey = session.r.get("myKey")
 
         # NOTE Set the value of key name to value if key doesn’t exist
         session.r.setnx(session.redis_key("count"), 1)

--- a/example_redis.py
+++ b/example_redis.py
@@ -10,6 +10,9 @@ from lona.html import H1, HTML, P
 from loguru import logger
 
 
+# NOTE start Redis before starting this lona script
+# docker run -p 6379:6379 -it redis:latest --requirepass "abcd1234"
+
 app = App(__file__)
 
 app.settings.SESSIONS = True
@@ -17,8 +20,12 @@ app.settings.MIDDLEWARES = [
     "lona_redis.middlewares.RedisSessionMiddleware",
 ]
 
-app.settings.REDIS_USER = "some_redis_user"
-app.settings.REDIS_PASSWORD = "abcd1234"
+# app.settings.REDIS_USER = "some_redis_user"
+# app.settings.REDIS_PASSWORD = "abcd1234"
+
+# FIXME suggested way to pass Redis connection settings
+# there are many many kwargs: https://redis.readthedocs.io/en/latest/connections.html
+app.settings.REDIS_CONNECTION = {"password": "abcd1234"}
 
 
 @app.route("/")
@@ -34,6 +41,8 @@ class Index(View):
         # request.user.session.set(foo=foo)
         # foo = request.user.session.get("foo")
         # logger.debug(f"{foo=}")
+
+        # NOTE example of getting the actual redis key given user's key
         # logger.debug(f"{request.user.session._actual_redis_key('foo')=}")
 
         request.user.session.set(str_var="hello world")

--- a/lona_redis/middlewares.py
+++ b/lona_redis/middlewares.py
@@ -14,13 +14,12 @@ class RedisSession:
         initalize redis.Redis()
 
         https://redis.readthedocs.io/en/latest/#quickly-connecting-to-redis
-        https://redis.readthedocs.io/en/latest/examples/connection_examples.html
 
-        there are many many kwargs:
+        but there are many many kwargs:
         https://redis.readthedocs.io/en/latest/connections.html
         """
 
-        # FIXME pass kwargs straight through to redis.Redis?
+        # FIXME suggest to pass kwargs through to redis.Redis
         self.r = redis.Redis(**kwargs)
 
     def _actual_redis_key(self, user_key):
@@ -40,7 +39,6 @@ class RedisSession:
         """
         for user_key, value in kwargs.items():
             actual_redis_key = self._actual_redis_key(user_key)
-            # logger.debug(f"{user_key=} {actual_redis_key=} {value=}")
             self.r.set(actual_redis_key, pickle.dumps(value))
 
     # def get(self, *args, **kwargs):
@@ -55,20 +53,18 @@ class RedisSession:
         """
         user_key = args[0]
         actual_redis_key = self._actual_redis_key(user_key)
-        # logger.debug(f"{user_key=} {actual_redis_key=}")
-
         return pickle.loads(self.r.get(actual_redis_key))
 
 
 # FIXME this isn't used - can be removed?
-class RedisUser:
-    def __init__(self, connection):
-        # self.connection = connection
-        # self.session = RedisSession(self)
-        pass
-
-    def __eq__(self, other):
-        raise NotImplementedError()
+# class RedisUser:
+#    def __init__(self, connection):
+#        # self.connection = connection
+#        # self.session = RedisSession(self)
+#        pass
+#
+#    def __eq__(self, other):
+#        raise NotImplementedError()
 
 
 class RedisSessionMiddleware:
@@ -79,31 +75,31 @@ class RedisSessionMiddleware:
 
         settings = data.server.settings
 
-        # FIXME
-        # TODO what should the settings be?
-        # TODO there are many kwargs (https://redis.readthedocs.io/en/latest/connections.html)
-        # TODO maybe settings should be a dict to override the defaults?
+        # FIXME how to set Redis connection settings?
+        # there are many many kwargs (https://redis.readthedocs.io/en/latest/connections.html)
+        # FIXME maybe settings should be a dict instead
 
         # logger.debug(f"{settings.REDIS_USER=}")
         # logger.debug(f"{settings.REDIS_PASSWORD=}")
 
-        # default args
-        # self.redis_session = RedisSession(host="localhost", port=6379, db=0)
+        # common setting, using default args (ie. host="localhost", port=6379, db=0)
+        # self.redis_session = RedisSession()
 
-        # FIXME pass kwargs (see above)
-        self.redis_session = RedisSession()
+        # FIXME suggested way to pass & use Redis connection settings
+        # logger.debug(f"{settings.REDIS_CONNECTION=}")
+        self.redis_session = RedisSession(**settings.REDIS_CONNECTION)
 
-        # to be set in handle_request()
+        # initalize this here, but to be set in handle_request()
         # just prior to user calling request.user.session.get(), request.user.session.set()
         self.user_request_session_key = None
 
         return data
 
-    def handle_connection(self, data):
-        # connection.user = RedisUser(data.connection)
-        # logger.debug(f"{dir(data.connection)=}")
-
-        return data
+    # FIXME this isn't used - can be removed?
+    # def handle_connection(self, data):
+    #    # connection.user = RedisUser(data.connection)
+    #
+    #    return data
 
     def handle_request(self, data):
         request = data.request

--- a/lona_redis/middlewares.py
+++ b/lona_redis/middlewares.py
@@ -103,6 +103,24 @@ class RedisSession:
         redis_key = self.redis_key(user_key)
         return self.r.exists(redis_key) == 1
 
+    def delete(self, user_key):
+        """
+        delete user_key
+        eg. request.user.session.delete("foo")
+
+        return
+            True if key existed and was deleted
+            False otherwise
+
+        as compared to:
+            https://redis.readthedocs.io/en/latest/commands.html#redis.commands.core.CoreCommands.delete
+
+        only accept 1 argument, return True/False
+        """
+
+        redis_key = self.redis_key(user_key)
+        return self.r.delete(redis_key) == 1
+
 
 # FIXME this isn't used - can be removed?
 # class RedisUser:

--- a/lona_redis/middlewares.py
+++ b/lona_redis/middlewares.py
@@ -5,8 +5,9 @@ from loguru import logger
 
 
 class RedisSession:
+    # FIXME this isn't used - can be removed?
     # def __init__(self, redis_user):
-    # self.redis_user = redis_user
+    #   self.redis_user = redis_user
 
     def __init__(self, *args, **kwargs):
         """
@@ -19,29 +20,27 @@ class RedisSession:
         https://redis.readthedocs.io/en/latest/connections.html
         """
 
-        # logger.debug("init RedisSession")
         # FIXME pass kwargs straight through to redis.Redis?
         self.r = redis.Redis(**kwargs)
-        self.user_request_session_key = None
 
     def _actual_redis_key(self, user_key):
         """
         combine self.user_request_session_key with user's key
         so that the ACTUAL key used to store value in Redis is unique
         """
-        user_request_session_key = self.user_request_session_key
-        return user_request_session_key + ":" + user_key
+        COMBINE_CHR = ":"
+        return self.user_request_session_key + COMBINE_CHR + user_key
 
     def set(self, *args, **kwargs):
         """
-        let user easily set values
+        user should call this to easily set values
         eg. request.user.session.set(foo=123)
+
+        pickle all values so that Redis can store any pickle-able Python value
         """
-        # logger.debug(f"set RedisSession {args=} {kwargs=}")
         for user_key, value in kwargs.items():
             actual_redis_key = self._actual_redis_key(user_key)
             # logger.debug(f"{user_key=} {actual_redis_key=} {value=}")
-            # self.r.set(actual_redis_key, value)
             self.r.set(actual_redis_key, pickle.dumps(value))
 
     # def get(self, *args, **kwargs):
@@ -49,17 +48,19 @@ class RedisSession:
 
     def get(self, *args):
         """
-        let user easily get values
+        user should call this to easily get values
         eg. request.user.session.get("foo")
+
+        un-pickle all values that were retrieved from Redis
         """
         user_key = args[0]
         actual_redis_key = self._actual_redis_key(user_key)
         # logger.debug(f"{user_key=} {actual_redis_key=}")
 
-        # return self.r.get(actual_redis_key)
         return pickle.loads(self.r.get(actual_redis_key))
 
 
+# FIXME this isn't used - can be removed?
 class RedisUser:
     def __init__(self, connection):
         # self.connection = connection
@@ -78,7 +79,7 @@ class RedisSessionMiddleware:
 
         settings = data.server.settings
 
-        # FIXME FIXME FIXME
+        # FIXME
         # TODO what should the settings be?
         # TODO there are many kwargs (https://redis.readthedocs.io/en/latest/connections.html)
         # TODO maybe settings should be a dict to override the defaults?
@@ -89,10 +90,11 @@ class RedisSessionMiddleware:
         # default args
         # self.redis_session = RedisSession(host="localhost", port=6379, db=0)
 
-        # FIXME pass kwargs (see note above)
+        # FIXME pass kwargs (see above)
         self.redis_session = RedisSession()
 
-        # to be set in handle_request() just prior to allowing user to call get(), set()
+        # to be set in handle_request()
+        # just prior to user calling request.user.session.get(), request.user.session.set()
         self.user_request_session_key = None
 
         return data

--- a/lona_redis/middlewares.py
+++ b/lona_redis/middlewares.py
@@ -1,26 +1,118 @@
-class RedisSession:
-    def __init__(self, redis_user):
-        self.redis_user = redis_user
+import pickle
 
-    def get(self, *args, **kwargs):
-        raise NotImplementedError()
+import redis
+from loguru import logger
+
+
+class RedisSession:
+    # def __init__(self, redis_user):
+    # self.redis_user = redis_user
+
+    def __init__(self, *args, **kwargs):
+        """
+        initalize redis.Redis()
+
+        https://redis.readthedocs.io/en/latest/#quickly-connecting-to-redis
+        https://redis.readthedocs.io/en/latest/examples/connection_examples.html
+
+        there are many many kwargs:
+        https://redis.readthedocs.io/en/latest/connections.html
+        """
+
+        # logger.debug("init RedisSession")
+        # FIXME pass kwargs straight through to redis.Redis?
+        self.r = redis.Redis(**kwargs)
+        self.user_request_session_key = None
+
+    def _actual_redis_key(self, user_key):
+        """
+        combine self.user_request_session_key with user's key
+        so that the ACTUAL key used to store value in Redis is unique
+        """
+        user_request_session_key = self.user_request_session_key
+        return user_request_session_key + ":" + user_key
 
     def set(self, *args, **kwargs):
-        raise NotImplementedError()
+        """
+        let user easily set values
+        eg. request.user.session.set(foo=123)
+        """
+        # logger.debug(f"set RedisSession {args=} {kwargs=}")
+        for user_key, value in kwargs.items():
+            actual_redis_key = self._actual_redis_key(user_key)
+            # logger.debug(f"{user_key=} {actual_redis_key=} {value=}")
+            # self.r.set(actual_redis_key, value)
+            self.r.set(actual_redis_key, pickle.dumps(value))
+
+    # def get(self, *args, **kwargs):
+    #    raise NotImplementedError()
+
+    def get(self, *args):
+        """
+        let user easily get values
+        eg. request.user.session.get("foo")
+        """
+        user_key = args[0]
+        actual_redis_key = self._actual_redis_key(user_key)
+        # logger.debug(f"{user_key=} {actual_redis_key=}")
+
+        # return self.r.get(actual_redis_key)
+        return pickle.loads(self.r.get(actual_redis_key))
 
 
 class RedisUser:
     def __init__(self, connection):
-        self.connection = connection
-        self.session = RedisSession(self)
+        # self.connection = connection
+        # self.session = RedisSession(self)
+        pass
 
     def __eq__(self, other):
         raise NotImplementedError()
 
 
 class RedisSessionMiddleware:
-    def handle_connection(self, data):
-        connection.user = RedisUser(data.connection)
+    async def on_startup(self, data):
+        """
+        initalize Redis connection
+        """
+
+        settings = data.server.settings
+
+        # FIXME FIXME FIXME
+        # TODO what should the settings be?
+        # TODO there are many kwargs (https://redis.readthedocs.io/en/latest/connections.html)
+        # TODO maybe settings should be a dict to override the defaults?
+
+        # logger.debug(f"{settings.REDIS_USER=}")
+        # logger.debug(f"{settings.REDIS_PASSWORD=}")
+
+        # default args
+        # self.redis_session = RedisSession(host="localhost", port=6379, db=0)
+
+        # FIXME pass kwargs (see note above)
+        self.redis_session = RedisSession()
+
+        # to be set in handle_request() just prior to allowing user to call get(), set()
+        self.user_request_session_key = None
 
         return data
 
+    def handle_connection(self, data):
+        # connection.user = RedisUser(data.connection)
+        # logger.debug(f"{dir(data.connection)=}")
+
+        return data
+
+    def handle_request(self, data):
+        request = data.request
+
+        # set self.user_request_session_key to request.user.session_key
+        # so that subsequent calls by the user to
+        # self.redis_session.set, self.redis_session.get
+        #   ie. in app->View->handle_request() : request.user.session.set(), request.user.session.get()
+        # will have request.user.session_key available
+        # we NEED this so that each Redis key is unique to request.user.session_key
+        self.redis_session.user_request_session_key = request.user.session_key
+        request.user.session = self.redis_session
+
+        return data


### PR DESCRIPTION
Lots of updates:

README.md
- started on docs (wip)

example_redis.py
- I wasn't sure where to put this
- just for testing & playing around with setting/getting values
- shows "easy" get/set
- shows direct access to redis connection to execute **actual** Redis commands

lona_redis/middlewares.py
- a first pass of how it might / would work
- I know you said that you wanted smaller multiple settings keys, but Redis has so many kwargs for setting up the connection (https://redis.readthedocs.io/en/latest/connections.html). I'm not sure how to reconcile - open to suggestions / direction

tests
- I know I should but I don't know how to do them in this case, with the browser interactivity :-(

Everything is open for comment / changes

Thanks!